### PR TITLE
Proposal to change the format of NIP05

### DIFF
--- a/05.md
+++ b/05.md
@@ -6,7 +6,7 @@ Mapping Nostr keys to DNS-based internet identifiers
 
 `final` `optional`
 
-On events of kind `0` (`user metadata`) one can specify the key `"nip05"` with an [internet identifier](https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1) (an email-like address) as the value. Although there is a link to a very liberal "internet identifier" specification above, NIP-05 assumes the `<local-part>` part will be restricted to the characters `a-z0-9-_.`, case-insensitive.
+On events of kind `0` (`user metadata`) one can specify the key `"nip05"` with an @domain name as the value. So the identifier would read as: @[name].domainname. The advantage of this over the email address is as follows. Although there is a link to a very liberal "internet identifier" specification above, NIP-05 assumes the `<local-part>` part will be restricted to the characters `a-z0-9-_.`, case-insensitive.
 
 Upon seeing that, the client splits the identifier into `<local-part>` and `<domain>` and use these values to make a GET request to `https://<domain>/.well-known/nostr.json?name=<local-part>`.
 


### PR DESCRIPTION
I’m proposing the Nostr community reformat the default NIP05 to @[handle].[domain]. 
By utilizing this format we simplify the different names, handles, ids users can acquire while in Nostr, create a nicer user experience, and enable users to have a true home on Nostr. 
Simplifying the identity experience in Nostr

When users in Nostr create an account they can add a display name, user handle, in addition to the npub and nsec they receive automatically. Without much effort we’ve given people 4 pieces of information to track about themselves that are completely new. In addition if they also enable a wallet they obtain a 5th identifier that also resembles the user handle. 

On more than one occasion people have asked me both why the handle is formatted like an email address and why they have a Nostr handle and a separate lightning wallet address. 

**Easing the user experience to improve discovery and interaction** 

As app developers the current email address format most clients default to makes it challenging to make use of the handle as an identifier in the app. If we make the NIP05 email address format clickable- devices and browsers will treat it like an email address and open an email client when in reality the use of the NIP05 was meant as a link to a user profile. 

If the client chooses not to link email formatted NIP05 then the user needs to copy it and paste it into a search box (often in another tab) to find the user being mentioned in a note. At this point the opportunity to make a connection is often lost. If the NIP05 followed the @[name].[domain] format a link could go to the profile in question. 

**NIP05’s as the new internet identity** 

Today if you drop a NIP05 of a nos.social user into a browser bar as a url so Linda.nos.social instead of linda@nos.social - you find an njump me page with my Nostr profile info. Asking new-to-Nostr users to understand that they can also hand out the url instead of the email address formatted NIP05 is generating a lot of cognitive load on our users. It also seems like a missed opportunity to get more people to discover Nostr and join. 
